### PR TITLE
SAP Blogs - Wrong format tag filter (ampersand)

### DIFF
--- a/src/controller/Main.controller.ts
+++ b/src/controller/Main.controller.ts
@@ -202,7 +202,7 @@ export default class Main extends BaseController {
         text: SAPBlogs[i].getText(),
         title: SAPBlogs[i].getText(),
         type: "rss",
-        xmlUrl: `https://content.services.sap.com/feed?type=blogpost&amp;tags=&amp;${SAPBlogs[i].getKey()}`,
+        xmlUrl: `https://content.services.sap.com/feed?type=blogpost&amp;tags=${SAPBlogs[i].getKey()}`,
         htmlUrl: `https://blogs.sap.com/tags/${SAPBlogs[i].getKey()}`,
       });
     }


### PR DESCRIPTION
Currently the generated links for SAP Blogs don't work correctly, the ampersand in the tags filter causes the filter not to work. Removing the wrongful ampersand fixes this issue.

The generated format before change:
https://content.services.sap.com/feed?type=blogpost&amp;tags=&amp;73554900100700000996 
Corrected format after change
https://content.services.sap.com/feed?type=blogpost&amp;tags=73554900100700000996